### PR TITLE
Lock accessibility score at 96

### DIFF
--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -12,5 +12,10 @@ module.exports = {
     upload: {
       target: 'temporary-public-storage',
     },
+    assert: {
+      assertions: {
+        'categories:accessibility': ['error', {minScore: 0.96}]
+      }
+    }
   },
 };


### PR DESCRIPTION
<!-- YOU SHOULD KNOW: dotcom is running an experiment called PR Deployments. -->
<!-- As soon as you open this PR, a github action called PR Deployment will run your code in an isolated environment and make it accessible in a public URL that you can use for testing etc -->
<!-- Every time you push to this branch, you will get an annoying email alert from github telling you that the previous PR deployment has been canceled. -->
<!-- You do not need to wait for the PR deployment action to go green before you can merge -->


## What does this change?
 let's see this fail
### Before

### After

## Why?
